### PR TITLE
Making OVE release NPM Ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Features
 
-Initial Release of [Open Visualization Environment (OVE)](https://github.com/ove/ove).
+**feat:** Initial Release of [Open Visualization Environment (OVE)](https://github.com/ove/ove).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+<a name="0.1.0"></a>
+# [0.1.0](https://github.com/ove/ove/compare/2ecb6b9...v0.1.0) (2018-10-03)
+
+### Features
+
+Initial Release of [Open Visualization Environment (OVE)](https://github.com/ove/ove).

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint-plugin-promise": "4.0.1",
     "eslint-plugin-standard": "4.0.0",
     "lerna": "3.4.0",
-    "rimraf": "2.6.2"
+    "rimraf": "2.6.2",
+    "copyfiles": "2.1.0"
   }
 }

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,0 +1,2 @@
+**/CHANGELOG.md
+**/LICENSE

--- a/packages/ove-core/package.json
+++ b/packages/ove-core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@ove/ove-core",
+  "private": true,
   "version": "0.1.0",
   "description": "The Core library of OVE",
   "main": "dist/index.js",
@@ -14,7 +15,7 @@
   "author": "Senaka Fernando <senaka.fernando15@imperial.ac.uk>",
   "license": "MIT",
   "dependencies": {
-    "@ove/ove-lib-utils": "^0.1.0",
+    "@ove-lib/utils": "^0.1.0",
     "cors": "2.8.4",
     "express": "4.16.3",
     "express-ws": "4.0.0",

--- a/packages/ove-core/src/index.js
+++ b/packages/ove-core/src/index.js
@@ -14,7 +14,7 @@ const dirs = {
     constants: path.join(__dirname, 'client', 'utils'),
     rootPage: path.join(__dirname, 'blank.html')
 };
-const { Constants, Utils } = require('@ove/ove-lib-utils')(app, 'core', dirs);
+const { Constants, Utils } = require('@ove-lib/utils')(app, 'core', dirs);
 const log = Utils.Logger('OVE');
 const clients = JSON.parse(fs.readFileSync(path.join(__dirname, 'client', Constants.CLIENTS_JSON_FILENAME)));
 

--- a/packages/ove-lib-appbase/README.md
+++ b/packages/ove-lib-appbase/README.md
@@ -1,0 +1,25 @@
+# `@ove-lib/appbase`
+
+> Base library for [Open Visualization Environment (OVE)](https://github.com/ove/ove) applications. This library depends on [@ove-lib/utils](https://www.npmjs.com/package/@ove-lib/utils).
+
+## Install
+
+```bash
+npm install @ove-lib/appbase --save
+```
+
+## Usage
+
+```js
+const express = require('express');
+const app = express();
+const dirs = {
+    base: __dirname,
+    nodeModules: path.join(__dirname, '..', 'node_modules'),
+    constants: path.join(__dirname, 'constants'),
+    rootPage: path.join(__dirname, 'client', 'blank.html')
+};
+const { Constants, Utils } = require('@ove-lib/utils')(app, 'myapp', dirs);
+const log = Utils.Logger('myapp');
+log.debug('Starting application:', 'myapp');
+```

--- a/packages/ove-lib-appbase/package.json
+++ b/packages/ove-lib-appbase/package.json
@@ -1,17 +1,21 @@
 {
-  "name": "@ove/ove-lib-appbase",
+  "name": "@ove-lib/appbase",
   "version": "0.1.0",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npx rimraf lib",
-    "build": "npx babel-cli src --out-dir lib --copy-files"
+    "build": "npx babel-cli src --out-dir lib --copy-files",
   },
-  "keywords": [],
+  "files": ["lib/*"],
+  "keywords": ["OVE"],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Senaka Fernando <senaka.fernando15@imperial.ac.uk>",
   "license": "MIT",
   "dependencies": {
-    "@ove/ove-lib-utils": "^0.1.0",
+    "@ove-lib/utils": "^0.1.0",
     "express": "4.16.3",
     "cors": "2.8.4",
     "http-status-codes": "1.3.0",

--- a/packages/ove-lib-appbase/src/index.js
+++ b/packages/ove-lib-appbase/src/index.js
@@ -11,7 +11,7 @@ module.exports = function (baseDir, appName) {
         nodeModules: path.join(baseDir, '..', '..', '..', 'node_modules'),
         constants: path.join(baseDir, 'client', 'constants')
     };
-    const { Constants, Utils } = require('@ove/ove-lib-utils')(app, appName, dirs);
+    const { Constants, Utils } = require('@ove-lib/utils')(app, appName, dirs);
     const log = Utils.Logger(appName);
 
     log.debug('Starting application:', appName);

--- a/packages/ove-lib-utils/README.md
+++ b/packages/ove-lib-utils/README.md
@@ -1,0 +1,24 @@
+# `@ove-lib/utils`
+
+> Core utility library for [Open Visualization Environment (OVE)](https://github.com/ove/ove) framework.
+
+## Install
+
+```bash
+npm install @ove-lib/utils --save
+```
+
+## Usage
+
+```js
+const path = require('path');
+const { express, app, log, nodeModules } = require('@ove-lib/appbase')(__dirname, 'myapp');
+const server = require('http').createServer(app);
+
+log.debug('Using module:', 'some_module');
+app.use('/', express.static(path.join(nodeModules, 'some_module', 'build')));
+
+const port = process.env.PORT || 8080;
+server.listen(port);
+log.info('application started, port:', port);
+```

--- a/packages/ove-lib-utils/package.json
+++ b/packages/ove-lib-utils/package.json
@@ -1,13 +1,17 @@
 {
-  "name": "@ove/ove-lib-utils",
+  "name": "@ove-lib/utils",
   "version": "0.1.0",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "npx rimraf lib",
-    "build": "npx babel-cli src --out-dir lib --copy-files"
+    "build": "npx babel-cli src --out-dir lib --copy-files",
   },
-  "keywords": [],
+  "files": ["lib/*"],
+  "keywords": ["OVE"],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Senaka Fernando <senaka.fernando15@imperial.ac.uk>",
   "license": "MIT",
   "dependencies": {
@@ -16,6 +20,7 @@
     "yamljs": "0.3.0",
     "chalk": "2.4.1",
     "dateformat": "3.0.3",
-    "http-status-codes": "1.3.0"
+    "http-status-codes": "1.3.0",
+    "jquery": "3.3.1"
   }
 }

--- a/packages/ove-lib-utils/src/index.js
+++ b/packages/ove-lib-utils/src/index.js
@@ -187,7 +187,7 @@ function Utils (app, appName, dirs) {
 **************************************************************/
 module.exports = function (app, appName, dirs) {
     // Constants are defined as follows:
-    //    1. System-wide within @ove/ove-lib-utils
+    //    1. System-wide within @ove-lib/utils
     //    2. Within OVE Core as a part of client utilities
     //    3. Within each app as a part of client constants
     // But, some apps may not be having specific constants of their own, and simply depend on the


### PR DESCRIPTION
This makes it possible to directly publish OVE into NPM, as the GitHub approach does not work since the URLs also need to be fixed in the `package.json` which is error prone and ugly.