### PR TITLE
Set example section sizes to fit LocalNine

### DIFF
--- a/packages/ove-core/src/server/swagger.yaml
+++ b/packages/ove-core/src/server/swagger.yaml
@@ -578,11 +578,11 @@ definitions:
       w:
         type: "integer"
         format: "int32"
-        example: 30720
+        example: 4320
       h:
         type: "integer"
         format: "int32"
-        example: 4320
+        example: 2424
   Section:
     description: "Used when creating or updating a section"
     properties:
@@ -615,11 +615,11 @@ definitions:
       w:
         type: "integer"
         format: "int32"
-        example: 30720
+        example: 4320
       h:
         type: "integer"
         format: "int32"
-        example: 4320
+        example: 2424
   UpdateOperation:
     description: "Used when updating multiple sections"
     properties:


### PR DESCRIPTION
The examples currently use a section resolution equal to 30720x4320, which is much larger than the LocalNine space in which they are created (4320x2424).