### PR TITLE
Don't treat 0 as NullOrEmpty

### DIFF
--- a/packages/ove-lib-utils/src/index.js
+++ b/packages/ove-lib-utils/src/index.js
@@ -282,7 +282,7 @@ function Utils (appName, app, dirs) {
     };
 
     this.isNullOrEmpty = function (input) {
-        return (!input && input !== 0) || this.JSON.equals(input, {}) || this.JSON.equals(input, []);
+        return (!input && input !== 0 && input !== false) || this.JSON.equals(input, {}) || this.JSON.equals(input, []);
     };
 }
 

--- a/packages/ove-lib-utils/src/index.js
+++ b/packages/ove-lib-utils/src/index.js
@@ -282,7 +282,7 @@ function Utils (appName, app, dirs) {
     };
 
     this.isNullOrEmpty = function (input) {
-        return !input || this.JSON.equals(input, {}) || this.JSON.equals(input, []);
+        return (!input && input !== 0) || this.JSON.equals(input, {}) || this.JSON.equals(input, []);
     };
 }
 

--- a/packages/ove-lib-utils/test/core-functionality.js
+++ b/packages/ove-lib-utils/test/core-functionality.js
@@ -38,6 +38,10 @@ describe('The OVE Utils library', () => {
     it('should test null or empty', () => {
         expect(Utils.isNullOrEmpty(null)).toBeTruthy();
         expect(Utils.isNullOrEmpty(undefined)).toBeTruthy();
+        expect(Utils.isNullOrEmpty(0)).not.toBeTruthy();
+        expect(Utils.isNullOrEmpty(false)).not.toBeTruthy();
+        expect(Utils.isNullOrEmpty('')).toBeTruthy();
+        expect(Utils.isNullOrEmpty(NaN)).toBeTruthy();
         expect(Utils.isNullOrEmpty({})).toBeTruthy();
         expect(Utils.isNullOrEmpty('test')).toBeFalsy();
         expect(Utils.isNullOrEmpty(10.1)).toBeFalsy();


### PR DESCRIPTION
In JS 0 evaluates to false. However, we probably don't want isNullOrEmpty to return false for 0.

For example, several apps call it from their canTransform method to check if required properties have values, and it is legitimate for many of these properties to be 0 (e.g., transformation.pan.x and transformation.pan.y).