### PR TITLE
Link from OVE Core landing page to OVE View pages

### DIFF
--- a/packages/ove-core/src/landing.html
+++ b/packages/ove-core/src/landing.html
@@ -162,6 +162,19 @@
                 .attr('y', d => (y(d.y + d.h/2) + sectionTextSize*0.5))
                 .style('font-size', sectionTextSize + 'px')
                 .classed('section-label', true);
+
+            divs.append('p')
+                .text('The OVE Clients corresponding to this space have the URLs:');
+
+            let ul = divs.append("ul");
+            ul.append('li').html(d => {
+                  return `<a href="${window.location}view.html?oveViewId=${d}-0"><code>${window.location}view.html?oveViewId=${d}-0</code></a>`
+            });
+            ul.append('li').html('...');
+            ul.append('li').html(d => {
+                let maxIndex = spaces[d].length - 1;
+                return `<a href="${window.location}view.html?oveViewId=${d}-${maxIndex}"><code>${window.location}view.html?oveViewId=${d}-${maxIndex}</code></a>`
+            });
         }
 
         function tabulateSections(spaces, sections) {

--- a/packages/ove-core/src/landing.html
+++ b/packages/ove-core/src/landing.html
@@ -172,7 +172,7 @@
             });
 
             ul.filter(d => spaces[d].length > 2)
-                .append('li').html('...');
+                .append('li').html('&nbsp;...');
 
             ul.filter(d => spaces[d].length > 1)
                 .append('li').html(d => {

--- a/packages/ove-core/src/landing.html
+++ b/packages/ove-core/src/landing.html
@@ -170,8 +170,12 @@
             ul.append('li').html(d => {
                   return `<a href="${window.location}view.html?oveViewId=${d}-0"><code>${window.location}view.html?oveViewId=${d}-0</code></a>`
             });
-            ul.append('li').html('...');
-            ul.append('li').html(d => {
+
+            ul.filter(d => spaces[d].length > 2)
+                .append('li').html('...');
+
+            ul.filter(d => spaces[d].length > 1)
+                .append('li').html(d => {
                 let maxIndex = spaces[d].length - 1;
                 return `<a href="${window.location}view.html?oveViewId=${d}-${maxIndex}"><code>${window.location}view.html?oveViewId=${d}-${maxIndex}</code></a>`
             });


### PR DESCRIPTION
This helps address the problem underlying #108, which is that users have to remember or look up the format of URLs for OVE Clients.