### PR TITLE
make socket debugging tool directly usable

### DIFF
--- a/packages/ove-core/src/index.js
+++ b/packages/ove-core/src/index.js
@@ -9,7 +9,8 @@ const dirs = {
     base: __dirname,
     nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules'),
     constants: path.join(__dirname, 'client', 'utils'),
-    rootPage: path.join(__dirname, 'landing.html')
+    rootPage: path.join(__dirname, 'landing.html'),
+    socketDebugPage: path.join(__dirname, 'socket-debug-tool.html')
 };
 const { Constants, Utils } = require('@ove-lib/utils')('core', app, dirs);
 const log = Utils.Logger('OVE');

--- a/packages/ove-core/src/landing.html
+++ b/packages/ove-core/src/landing.html
@@ -76,8 +76,11 @@
         function setAppName(element, url) {
             if (url) {
                 d3.json(url + '/name').then(name => {
+                    const sectionData = d3.select(element.parentElement).datum();
+                    const socketDebugURL = `./messages?oveAppName=${name}&oveSectionId=${sectionData.id}`;
+
                     const nameInTitleCase = name.charAt(0).toUpperCase() + name.substring(1);
-                    element.innerHTML = nameInTitleCase + ' (<a target=\'_blank\' href=\'' + url + '/api-docs/\'>API</a>)';
+                    element.innerHTML = `${nameInTitleCase} (<a target='_blank' href='${url}/api-docs/'>API</a>, <a target='_blank' href='${socketDebugURL}'>messages</a>)`;
                 });
             }
         }

--- a/packages/ove-core/src/socket-debug-tool.html
+++ b/packages/ove-core/src/socket-debug-tool.html
@@ -5,7 +5,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title></title>
+    <title>OVE WebSocket Debugging Tool</title>
     <link rel="shortcut icon" href="#">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.2.1/css/bootstrap.min.css" type="text/css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>

--- a/packages/ove-core/src/socket-debug-tool.html
+++ b/packages/ove-core/src/socket-debug-tool.html
@@ -13,16 +13,14 @@
         $(() => {
             const displayError = () => {
                 $('<div>').addClass('alert alert-danger').css({ display: 'table-cell' })
-                    .html('<strong>Error:</strong> Please provide <strong>oveHost</strong>, <strong>oveAppName</strong>, and <strong>oveSectionId</strong> query parameters.')
+                    .html('<strong>Error:</strong> Please provide <strong>oveAppName</strong>, and <strong>oveSectionId</strong> query parameters.')
                     .appendTo('.outer');
             };
             $('.outer').css({ margin: '0.5vw', display: 'block', width: '85vw' });
-            let hostname = new URLSearchParams(location.search.slice(1)).get('oveHost');
-            if (!hostname) {
-                displayError();
-                return;
-            }
+
+            let hostname = new URL(document.location).origin;
             hostname = hostname.substring(hostname.indexOf('//') + 2);
+
             $.getScript('http://' + hostname + '/ove.js', () => {
                 if (!OVE.Utils.getQueryParam('oveAppName') || !OVE.Utils.getQueryParam('oveSectionId')) {
                     displayError();
@@ -39,7 +37,7 @@
 </head>
 
 <body unselectable="on" class="unselectable bg-dark">
-    <div class="outer"></div>
+<div class="outer"></div>
 </body>
 
 </html>

--- a/packages/ove-lib-utils/src/index.js
+++ b/packages/ove-lib-utils/src/index.js
@@ -146,6 +146,10 @@ function Utils (appName, app, dirs) {
             });
         }
 
+        app.get('/messages', function (_req, res) {
+            res.sendFile(dirs.socketDebugPage);
+        });
+
         // Each CSS file is combination of {type}/{name}.css and common/{name}.css.
         // Each JS file is combination of {type}/{name}.js, common/{name}.js and
         // constants/{name}.js files from the filesystem.


### PR DESCRIPTION
Serve the socket debugigng page from OVE, and provide a link for
each section listed in the table on the landing page.